### PR TITLE
Add guidance for Azure ARM VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Make sure that you're running Windows 11 version 24H2 **build 26100.712** before
 
 Most x86_64 users will have to wait until Microsoft publishes AI Components for their platform. _However_, if you're feeling particularly adventurous you can try [Emulating Arm64 Windows on your x86_64 Windows PC](https://github.com/thebookisclosed/AmperageKit/blob/main/ArmOnX86_64.md)
 
+26100.712 is also available on [Azure ARM VMs](https://learn.microsoft.com/en-us/windows/arm/create-arm-vm) by using a 24H2 image (currently 26100.560) and installing KB5037589.
+
 # How do I get started?
 1) Download the AI Components (Machine Learning workloads) for Arm64 from [here](https://archive.org/details/windows-workloads-0.3.252.0-arm-64.7z)
 2) Unpack the contents of the 7z archive to a folder called `WorkloadComponents`


### PR DESCRIPTION
Hi, thanks so much for your work over the years 😊

There are first-party 26100.560 ARM Pro/Ent images on Azure, so I found it easier to upgrade to 26100.712 with KB5037589 rather than emulating. I used an 8vCPU/8GB SKU (B8pls) in case hardware requirements still apply.